### PR TITLE
Feature: adds a command line interface to prompt for a single user

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,32 @@
+"creates a temporary csv file for a single user and feeds it to update-iam-human script"
+
+import csv, tempfile
+from . import main as update_iam_human
+import argparse
+
+def prompt(field):
+    uin = input("%s: " % field)
+    return uin
+
+def main(execute=False):
+    field_names = ['name', 'email', 'iam-username']
+    try:
+        with tempfile.NamedTemporaryFile('w+') as csv_path:
+            writer = csv.writer(csv_path, field_names)
+            writer.writerow(field_names)
+
+            #row = ['Luke Test', 'l.skibinski@elifesciences.org', 'LukeTest']
+            row = list(map(prompt, field_names))
+            writer.writerow(row)
+
+            csv_path.seek(0)
+            update_iam_human.main(csv_path.name, execute=execute)
+
+    except KeyboardInterrupt:
+        print('ctrl-c caught, quitting')
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--execute', default=False, action='store_true')
+    kwargs = parser.parse_args().__dict__ # {'execute': False}
+    main(**kwargs)

--- a/src/main.py
+++ b/src/main.py
@@ -430,7 +430,7 @@ if __name__ == '__main__':
         parser.add_argument('--execute', default=False, action='store_true')
         parser.add_argument('--max-key-age', default=MAX_KEY_AGE_DAYS)
         parser.add_argument('--grace-period-days', default=GRACE_PERIOD_DAYS)
-        kwargs = parser.parse_args().__dict__ # "{'user_csvpath': 'example.csv', 'execute': False, 'max_key_age': 180, 'grace_period_days': 7}"
+        kwargs = parser.parse_args().__dict__ # {'user_csvpath': 'example.csv', 'execute': False, 'max_key_age': 180, 'grace_period_days': 7}
         sys.exit(main(**kwargs))
     except AssertionError as err:
         print('err:', err)

--- a/update-iam-prompt.sh
+++ b/update-iam-prompt.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+source venv/bin/activate
+python -m src.cli $@


### PR DESCRIPTION
Rowena was slow to update and her gist was deleted before she could update. I deleted her new credentials and re-ran the script using a modified csv file. That was a bit of a pita so I threw this together.

It lets you feed in a name/email/iam username to the update-iam-human script and have it create/update/delete credentials as it sees fit. Just like the main script, you get a chance to review the changes to be made before running the actions with `--execute`